### PR TITLE
Edit demoAllComponents.ino: in "GP.NAV_TABS_LINKS".

### DIFF
--- a/examples/demos/demoAllComponents/demoAllComponents.ino
+++ b/examples/demos/demoAllComponents/demoAllComponents.ino
@@ -16,7 +16,7 @@ void build() {
   GP.TITLE("GyverPortal");
   GP.HR();
 
-  GP.NAV_TABS_LINKS("/,/home,/sett,/kek", "Home,Settings,Kek");
+  GP.NAV_TABS_LINKS("/home,/sett,/kek", "Home,Settings,Kek");
   
   M_SPOILER(
     "Spoiler",


### PR DESCRIPTION
Ожидаемое поведение при клике, например, на ссылку 'Kek' переход на страницу `http://192.168.0.ххх/kek` (остальные ссылки соответственно).
Сейчас из-за того что в первой половине конструкции 4 элемента: `GP.NAV_TABS_LINKS("/,/home,/sett,/kek", ` а во второй 3: `"Home,Settings,Kek");` происходит рассинхрон:
![image](https://github.com/GyverLibs/GyverPortal/assets/49735406/da6d3c79-37c5-42bd-8793-5be09079c5ee)